### PR TITLE
Move share to fix desktop file and icons, fix indentation

### DIFF
--- a/io.github.cloose.CuteMarkEd.json
+++ b/io.github.cloose.CuteMarkEd.json
@@ -6,6 +6,8 @@
 	"runtime-version": "5.15",
 	"sdk": "org.kde.Sdk",
 	"command": "cutemarked",
+	"rename-desktop-file": "cutemarked.desktop",
+	"rename-icon": "cutemarked",
 	"finish-args":[
 		"--socket=wayland",
 		"--socket=x11",
@@ -41,17 +43,17 @@
 		{
 			"name": "cutemarked",
 			"buildsystem": "qmake",
-            "make-install-args": [
-                "INSTALL_ROOT=/app"
-            ],
+			"make-install-args": [
+				"INSTALL_ROOT=/app"
+			],
 			"build-options":{
 				"env":{
 					"QMAKEPATH": "/app/lib"
 				}
 			},
 			"config-opts": [
-                "QMAKE_LIBDIR=/app/lib"
-            ],
+				"QMAKE_LIBDIR=/app/lib"
+			],
 			"sources":[
 				{
 					"type":"archive",
@@ -59,12 +61,14 @@
 					"sha256": "78a41808c2f0452375810abdff76eeaaee012f8d1368a2b8772ec6b4d2ceeec8"
 				},
 				{
-                    "type": "patch",
-                    "path": "0001-Fix-build-issues-with-recents-Qt-versions.patch"
+					"type": "patch",
+					"path": "0001-Fix-build-issues-with-recents-Qt-versions.patch"
 				}
 			],
 			"post-install":[
-				"mv /app/app/bin/* /app/bin"
+				"mv /app/app/bin/* /app/bin",
+				"mv /app/app/share/* /app/share",
+				"rm -rf /app/usr/"
 			]
 		},
 		{


### PR DESCRIPTION
This also has a workaround for appstream

This fixes the regression as pointed out here : https://github.com/flathub/io.github.cloose.CuteMarkEd/pull/5#issuecomment-860064660